### PR TITLE
Simplify refresh token handling

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -33,7 +33,7 @@ func handleRegister(w http.ResponseWriter, req *http.Request) {
 	w.Write([]byte{0x00})
 }
 
-func createRefreshToken() string {
+func createRefreshToken(id string) string {
 	token := make([]byte, 32)
 	_, err := rand.Read(token)
 	if err != nil {
@@ -42,7 +42,7 @@ func createRefreshToken() string {
 
 	tokenStr := b64.StdEncoding.EncodeToString(token)
 
-	return tokenStr
+	return id + ":" + tokenStr
 }
 
 type resToken struct {
@@ -67,17 +67,19 @@ func handleLogin(w http.ResponseWriter, req *http.Request) {
 	var err error
 	if grantType[0] == "refresh_token" {
 		rrefreshToken := req.PostForm["refresh_token"][0]
-		if len(rrefreshToken) < 4 {
+		rt := strings.Split(rrefreshToken, ":")
+		if len(rt) != 2 {
 			// Fatal to always catch this
 			log.Fatal("fake refreshToken " + rrefreshToken)
 		}
 
-		acc, err = db.getAccount("", rrefreshToken)
+		acc, err = db.getAccount(rt[0])
 		if err != nil {
+			log.Println("account not found")
 			log.Fatal(err)
 		}
-		log.Println(acc.Email + " is trying to refresh a token " + rrefreshToken)
-		if acc.RefreshToken != rrefreshToken {
+		log.Println(acc.Email + " is trying to refresh a token " + rt[1])
+		if acc.RefreshToken != rt[1] {
 			w.WriteHeader(http.StatusUnauthorized)
 			w.Write([]byte(http.StatusText(401)))
 			log.Println("Login attempt failed")
@@ -90,7 +92,7 @@ func handleLogin(w http.ResponseWriter, req *http.Request) {
 
 		log.Println(username + " is trying to login")
 
-		acc, err = db.getAccount(username, "")
+		acc, err = db.getAccount(username)
 		if acc.MasterPasswordHash != passwordHash {
 			w.WriteHeader(http.StatusUnauthorized)
 			w.Write([]byte(http.StatusText(401)))
@@ -100,8 +102,8 @@ func handleLogin(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Create refreshtoken and store in db
-	refreshToken := createRefreshToken()
-	err = db.updateAccountInfo(acc.Id, refreshToken)
+	acc.RefreshToken = createRefreshToken(acc.Id)
+	err = db.updateAccountInfo(acc)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -121,7 +123,7 @@ func handleLogin(w http.ResponseWriter, req *http.Request) {
 	rtoken := resToken{AccessToken: tokenString,
 		ExpiresIn:    jwtExpire,
 		TokenType:    "Bearer",
-		RefreshToken: refreshToken,
+		RefreshToken: acc.RefreshToken,
 		Key:          acc.Key,
 	}
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -14,9 +14,9 @@ func TestHandleLogin(t *testing.T) {
 		data     url.Values
 		expected int
 	}{{url.Values{"grant_type": {"password"}, "username": {"nobody@example.com"}, "password": {"base64password"}}, 200},
-		{url.Values{"grant_type": {"refresh_token"}, "refresh_token": {"abcdef"}}, 200},
+		{url.Values{"grant_type": {"refresh_token"}, "refresh_token": {"1:abcdef"}}, 200},
 		{url.Values{"grant_type": {"password"}, "username": {"nobody@example.com"}, "password": {""}}, 401},
-		{url.Values{"grant_type": {"refresh_token"}, "refresh_token": {"nasdfasdf"}}, 401}}
+		{url.Values{"grant_type": {"refresh_token"}, "refresh_token": {"1:nasdfasdf"}}, 401}}
 
 	db = &mockDB{username: "nobody@example.com", password: "base64password", refreshToken: "abcdef"}
 

--- a/database.go
+++ b/database.go
@@ -201,8 +201,8 @@ func (db *DB) addAccount(acc Account) error {
 	return nil
 }
 
-func (db *DB) updateAccountInfo(sid string, refreshToken string) error {
-	id, err := strconv.ParseInt(sid, 10, 64)
+func (db *DB) updateAccountInfo(acc Account) error {
+	id, err := strconv.ParseInt(acc.Id, 10, 64)
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func (db *DB) updateAccountInfo(sid string, refreshToken string) error {
 		return err
 	}
 
-	_, err = stmt.Exec(refreshToken, id)
+	_, err = stmt.Exec(acc.RefreshToken, id)
 	if err != nil {
 		return err
 	}
@@ -220,16 +220,12 @@ func (db *DB) updateAccountInfo(sid string, refreshToken string) error {
 	return nil
 }
 
-func (db *DB) getAccount(username string, refreshtoken string) (Account, error) {
+func (db *DB) getAccount(username string) (Account, error) {
 	var row *sql.Row
 	acc := Account{}
 	if username != "" {
 		query := "SELECT * FROM accounts WHERE email = $1"
 		row = db.db.QueryRow(query, username)
-	}
-	if refreshtoken != "" {
-		query := "SELECT * FROM accounts WHERE refreshtoken = $1"
-		row = db.db.QueryRow(query, refreshtoken)
 	}
 
 	var iid int

--- a/database_mock.go
+++ b/database_mock.go
@@ -20,7 +20,7 @@ func (db *mockDB) open() error {
 func (db *mockDB) close() {
 }
 
-func (db *mockDB) updateAccountInfo(sid string, refreshToken string) error {
+func (db *mockDB) updateAccountInfo(acc Account) error {
 	return nil
 }
 
@@ -45,7 +45,7 @@ func (db *mockDB) addAccount(acc Account) error {
 	return nil
 }
 
-func (db *mockDB) getAccount(username string, refreshtoken string) (Account, error) {
+func (db *mockDB) getAccount(username string) (Account, error) {
 	return Account{Email: db.username, MasterPasswordHash: db.password, RefreshToken: db.refreshToken}, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func handleNewCipher(w http.ResponseWriter, req *http.Request) {
 
 	log.Println(email + " is trying to add data")
 
-	acc, err := db.getAccount(email, "")
+	acc, err := db.getAccount(email)
 	if err != nil {
 		log.Fatal("Account lookup " + err.Error())
 	}
@@ -63,7 +63,7 @@ func handleCipherUpdate(w http.ResponseWriter, req *http.Request) {
 	// Get the cipher id
 	id := req.URL.Path[len("/api/ciphers/"):]
 
-	acc, err := db.getAccount(email, "")
+	acc, err := db.getAccount(email)
 	if err != nil {
 		log.Fatal("Account lookup " + err.Error())
 	}
@@ -120,7 +120,7 @@ func handleSync(w http.ResponseWriter, req *http.Request) {
 
 	log.Println(email + " is trying to sync")
 
-	acc, err := db.getAccount(email, "")
+	acc, err := db.getAccount(email)
 
 	prof := Profile{
 		Id:               acc.Id,
@@ -174,7 +174,7 @@ func handleNewFolder(w http.ResponseWriter, req *http.Request) {
 
 	log.Println(email + " is trying to add a new folder")
 
-	acc, err := db.getAccount(email, "")
+	acc, err := db.getAccount(email)
 	if err != nil {
 		log.Fatal("Account lookup " + err.Error())
 	}
@@ -209,8 +209,8 @@ func handleNewFolder(w http.ResponseWriter, req *http.Request) {
 type database interface {
 	init() error
 	addAccount(acc Account) error
-	getAccount(username string, refreshtoken string) (Account, error)
-	updateAccountInfo(sid string, refreshToken string) error
+	getAccount(username string) (Account, error)
+	updateAccountInfo(acc Account) error
 	getCiphers(owner string) ([]Cipher, error)
 	newCipher(ciph Cipher, owner string) (Cipher, error)
 	updateCipher(newData Cipher, owner string, ciphID string) error


### PR DESCRIPTION
Encode user id into refresh token, so we can simply look up the user and compare it's refresh token.