### PR TITLE
Allow setting a directory for the database and create tables only if they don't exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Run the following to initalize the database:
 ```
 bitwarden-go -init
 ```
-This will create a database called ```db``` in the directory of the application.
+This will create a database called ```db``` in the directory of the application. Use `-location` to set a different directory for the database.
 
 #### Running
 To run [bitwarden-go](https://github.com/VictorNine/bitwarden-go), run the following in the terminal:

--- a/cmd/bitwarden-go/main.go
+++ b/cmd/bitwarden-go/main.go
@@ -13,6 +13,7 @@ import (
 
 var cfg struct {
 	initDB              bool
+	location            string
 	signingKey          string
 	jwtExpire           int
 	hostAddr            string
@@ -23,6 +24,7 @@ var cfg struct {
 
 func init() {
 	flag.BoolVar(&cfg.initDB, "init", false, "Initalizes the database.")
+	flag.StringVar(&cfg.location, "location", "", "Sets the directory for the database")
 	flag.StringVar(&cfg.signingKey, "key", "secret", "Sets the signing key")
 	flag.IntVar(&cfg.jwtExpire, "tokenTime", 3600, "Sets the ammount of time (in seconds) the generated JSON Web Tokens will last before expiry.")
 	flag.StringVar(&cfg.hostAddr, "host", "", "Sets the interface that the application will listen on.")
@@ -35,6 +37,7 @@ func main() {
 	db := &sqlite.DB{}
 	flag.Parse()
 
+	db.SetDir(cfg.location)
 	err := db.Open()
 	if err != nil {
 		log.Fatal(err)

--- a/internal/database/mock/database_mock.go
+++ b/internal/database/mock/database_mock.go
@@ -16,7 +16,7 @@ func (db *MockDB) Init() error {
 	return nil
 }
 
-func (db *DB) SetDir(d string) {
+func (db *MockDB) SetDir(d string) {
 }
 
 func (db *MockDB) Open() error {

--- a/internal/database/mock/database_mock.go
+++ b/internal/database/mock/database_mock.go
@@ -16,6 +16,9 @@ func (db *MockDB) Init() error {
 	return nil
 }
 
+func (db *DB) SetDir(d string) {
+}
+
 func (db *MockDB) Open() error {
 	return nil
 }

--- a/internal/database/sqlite/database.go
+++ b/internal/database/sqlite/database.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"path"
 	"strconv"
 	"time"
 
@@ -13,7 +14,8 @@ import (
 )
 
 type DB struct {
-	db *sql.DB
+	db  *sql.DB
+	dir string
 }
 
 func (db *DB) Init() error {
@@ -52,9 +54,17 @@ func (db *DB) Init() error {
 	return err
 }
 
+func (db *DB) SetDir(d string) {
+	db.dir = d
+}
+
 func (db *DB) Open() error {
 	var err error
-	db.db, err = sql.Open("sqlite3", "db")
+	if db.dir != "" {
+		db.db, err = sql.Open("sqlite3", path.Join(db.dir, "db"))
+	} else {
+		db.db, err = sql.Open("sqlite3", "db")
+	}
 	return err
 }
 

--- a/internal/database/sqlite/database.go
+++ b/internal/database/sqlite/database.go
@@ -17,9 +17,9 @@ type DB struct {
 }
 
 func (db *DB) Init() error {
-	query1 := "CREATE TABLE \"accounts\" (`id`	INTEGER,`name`	TEXT,`email`	TEXT UNIQUE,`masterPasswordHash`	NUMERIC,`masterPasswordHint`	TEXT,`key`	TEXT,`refreshtoken`	TEXT,`privatekey`	TEXT NOT NULL,`pubkey`	TEXT NOT NULL,PRIMARY KEY(id))"
-	query2 := "CREATE TABLE \"ciphers\" (`id`	INTEGER PRIMARY KEY AUTOINCREMENT,`type`	INTEGER,`revisiondate`	INTEGER,`data`	REAL,`owner`	INTEGER,`folderid`	TEXT,`favorite`	INTEGER NOT NULL)"
-	query3 := "CREATE TABLE \"folders\" (`id`	TEXT,	`name`	TEXT,	`revisiondate`	INTEGER,	`owner`	INTEGER, PRIMARY KEY(id))"
+	query1 := "CREATE TABLE IF NOT EXISTS \"accounts\" (`id`	INTEGER,`name`	TEXT,`email`	TEXT UNIQUE,`masterPasswordHash`	NUMERIC,`masterPasswordHint`	TEXT,`key`	TEXT,`refreshtoken`	TEXT,`privatekey`	TEXT NOT NULL,`pubkey`	TEXT NOT NULL,PRIMARY KEY(id))"
+	query2 := "CREATE TABLE IF NOT EXISTS \"ciphers\" (`id`	INTEGER PRIMARY KEY AUTOINCREMENT,`type`	INTEGER,`revisiondate`	INTEGER,`data`	REAL,`owner`	INTEGER,`folderid`	TEXT,`favorite`	INTEGER NOT NULL)"
+	query3 := "CREATE TABLE IF NOT EXISTS \"folders\" (`id`	TEXT,	`name`	TEXT,	`revisiondate`	INTEGER,	`owner`	INTEGER, PRIMARY KEY(id))"
 	stmt1, err := db.db.Prepare(query1)
 	if err != nil {
 		return err


### PR DESCRIPTION
I add this change for the reason that I would like to set the location of the database somewhere else than `./`, this is useful for binaries running inside a Docker container, we can save the database inside a Docker volume.

I also changed the SQL statement for creating the tables to create them only if they do not exist. This allow running the option `-init` more than once without triggering errors or breaking something in the database.